### PR TITLE
getErrorInfo should be called on $result, not $validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ $validator = new \Volan\Volan($schema);
 $result = $validator->validate($book);
 
 // if $result->isValid() === false you can get full information about invalid node
-var_dump($validator->getErrorInfo());
+var_dump($result->getErrorInfo());
 ```
 ## Predefined validators
 ### Strings


### PR DESCRIPTION
Hi,
Came across your library which I find great. I struggled to find the way to get the Error info and found out the docs were wrong. 

Thanks